### PR TITLE
Fixed TOC link to introduction

### DIFF
--- a/doc/Parity_Volume_Set_Specification_v3.0.html
+++ b/doc/Parity_Volume_Set_Specification_v3.0.html
@@ -34,7 +34,7 @@ Updated January 28th, 2022  (Official "Pre-reference implementation" draft)
 <p>This document describes a file format for storing redundant data. If any of the original data is damaged in storage or transmission, the redundant data can be used to regenerate the original input. Of course, not all damages can be repaired, but many can.</p>
 <h2 id="table-of-contents">Table of Contents</h2>
 <ul>
-<li><a href="introduction">Introduction</a></li>
+<li><a href="#introduction">Introduction</a></li>
 <li><a href="#prerequisites">Prerequisites</a>
 <ul>
 <li><a href="#use-case">Use Case</a></li>

--- a/doc/Parity_Volume_Set_Specification_v3.0.md
+++ b/doc/Parity_Volume_Set_Specification_v3.0.md
@@ -39,7 +39,7 @@ This document describes a file format for storing redundant data.  If any of the
 
 ## Table of Contents
 
-- [Introduction](introduction)
+- [Introduction](#introduction)
 - [Prerequisites](#prerequisites)
   - [Use Case](#use-case)
   - [Design Goals](#design-goals)


### PR DESCRIPTION
Fixed link in table of contents so that the link to the Introduction now works.

The old version (https://parchive.github.io/doc/Parity_Volume_Set_Specification_v3.0.html) erroneously linked to https://parchive.github.io/doc/introduction which gave a 404.